### PR TITLE
[PR] Preconfigure project sites with common defaults

### DIFF
--- a/wsuwp-admin.php
+++ b/wsuwp-admin.php
@@ -19,6 +19,7 @@ class WSU_Admin {
 		add_filter( 'srm_max_redirects', array( $this, 'srm_max_redirects' ), 10, 1 );
 		add_filter( 'document_revisions_enable_webdav', '__return_false' );
 		add_action( 'admin_init', array( $this, 'remove_events_calendar_actions' ), 9 );
+		add_action( 'wpmu_new_blog', array( $this, 'preconfigure_project_site' ), 10, 3 );
 	}
 
 	/**
@@ -81,6 +82,57 @@ class WSU_Admin {
 			remove_action( 'admin_init', array( $tribe_events, 'maybe_generate_geopoints_for_all_venues' ) );
 			remove_action( 'admin_init', array( $tribe_events, 'maybe_offer_generate_geopoints' ) );
 		}
+	}
+
+	/**
+	 * Preconfigure a Project site to reduce the overall setup experience.
+	 *
+	 *     - Use latest posts instead of page on front.
+	 *     - Restrict to logged in users by default.
+	 *     - Use the WSU Project (P2) theme rather than the Spine.
+	 *     - Force HTTPS
+	 *     - Configure default P2 related widgets in the sidebar.
+	 *     - Flush rewrite rules.
+	 *
+	 * @param int    $blog_id ID of the site being created.
+	 * @param int    $user_id ID of the user creating the site.
+	 * @param string $domain  Domain of the site being created.
+	 */
+	public function preconfigure_project_site( $blog_id, $user_id, $domain ) {
+		// Only apply these defaults to project sites.
+		if ( 'project.wsu.edu' !== $domain ) {
+			return;
+		}
+
+		switch_to_blog( $blog_id );
+
+		// Show posts on the front page rather than a page.
+		update_option( 'show_on_front', 'posts' );
+
+		// Activate the WSU Project theme by default.
+		update_option( 'stylesheet', 'p2-wsu' );
+		update_option( 'template', 'p2-wsu' );
+
+		// Restrict access to logged in users only.
+		update_option( 'blog_public', 2 );
+
+		// Replace HTTP with HTTPS in the site and home URLs.
+		$site_url = get_option( 'siteurl' );
+		$site_url = str_replace( 'http://', 'https://', $site_url );
+		update_option( 'siteurl', $site_url );
+		$home_url = get_option( 'home' );
+		$home_url = str_replace( 'http://', 'https://', $home_url );
+		update_option( 'home', $home_url );
+
+		// Setup common P2 widgets.
+		update_option( 'widget_mention_me', array( 2 => array( 'title' => '', 'num_to_show' => 5, 'avatar_size' => 32, 'show_also_post_followups' => false, 'show_also_comment_followups' => false ), '_multiwidget' => 1 ) );
+		update_option( 'widget_p2_recent_tags', array( 2 => array( 'title' => '', 'num_to_show' => 15 ), '_multiwidget' => 1 ) );
+		update_option( 'widget_p2_recent_comments', array( 2 => array( 'title' => '', 'num_to_show' => 5, 'avatar_size' => 32 ), '_multiwidget' => 1 ) );
+		update_option( 'sidebars_widgets',       array ( 'wp_inactive_widgets' => array (), 'sidebar-1' => array ( 0 => 'search-2', 1 => 'mention_me-2', 2 => 'p2_recent_tags-2', 3 => 'p2_recent_comments-2', 4 => 'recent-posts-2' ), 'sidebar-2' => array (), 'sidebar-3' => array (), 'array_version' => 3 ) );
+		restore_current_blog();
+
+		flush_rewrite_rules();
+
 	}
 }
 new WSU_Admin();


### PR DESCRIPTION
- Use latest posts instead of page on front.
- Restrict to logged in users by default.
- Use the WSU Project (P2) theme rather than the Spine.
- Force HTTPS
- Configure default P2 related widgets in the sidebar.
- Flush rewrite rules.
