### PR TITLE
[PR] Manually provide a Content-Type header for document requests

### DIFF
--- a/wsuwp-admin.php
+++ b/wsuwp-admin.php
@@ -224,7 +224,7 @@ class WSU_Admin {
 			return $headers;
 		}
 
-		$headers['Content-Type'] = $mime_type . '; charset=UTF-8';
+		$headers['Content-Type'] = esc_attr( $mime_type ) . '; charset=UTF-8';
 
 		return $headers;
 	}

--- a/wsuwp-admin.php
+++ b/wsuwp-admin.php
@@ -18,6 +18,7 @@ class WSU_Admin {
 		add_action( 'manage_posts_custom_column', array( $this, 'last_updated_column_data' ), 10, 2 );
 		add_filter( 'srm_max_redirects', array( $this, 'srm_max_redirects' ), 10, 1 );
 		add_filter( 'document_revisions_enable_webdav', '__return_false' );
+		add_filter( 'wp_headers', array( $this, 'document_revisions_headers' ), 10, 1 );
 		add_action( 'admin_init', array( $this, 'remove_events_calendar_actions' ), 9 );
 		add_action( 'wpmu_new_blog', array( $this, 'preconfigure_project_site' ), 10, 3 );
 		add_action( 'wpmu_new_blog', array( $this, 'preconfigure_sites_site' ), 10, 3 );
@@ -192,5 +193,34 @@ class WSU_Admin {
 		flush_rewrite_rules();
 	}
 
+	/**
+	 * Determine what Content-Type header should be sent with a document revisions
+	 * request. If we don't filter this, text/html is used by default as WordPress
+	 * sets the header before the WP Document Revisions plugin is able to.
+	 *
+	 * @param array $headers List of headers currently set for this request.
+	 *
+	 * @return array Modified list of headers.
+	 */
+	public function document_revisions_headers( $headers ) {
+		/* @var WPDB $wpdb */
+		global $wpdb, $wp;
+		if ( isset( $wp->query_vars['post_type'] ) && 'document' !== $wp->query_vars['post_type'] ) {
+			return $headers;
+		}
+
+		$post_id = $wpdb->get_var( $wpdb->prepare( "SELECT post_content FROM $wpdb->posts WHERE post_type='document' AND post_name = %s", sanitize_title( $wp->query_vars['name'] ) ) );
+		if ( empty( absint( $post_id ) ) ) {
+			return $headers;
+		}
+		$mime_type = $wpdb->get_var( $wpdb->prepare( "SELECT post_mime_type FROM $wpdb->posts WHERE ID = %d", $post_id ) );
+		if ( empty( $mime_type ) ) {
+			return $headers;
+		}
+
+		$headers['Content-Type'] = $mime_type . '; charset=UTF-8';
+
+		return $headers;
+	}
 }
 new WSU_Admin();

--- a/wsuwp-admin.php
+++ b/wsuwp-admin.php
@@ -205,14 +205,20 @@ class WSU_Admin {
 	public function document_revisions_headers( $headers ) {
 		/* @var WPDB $wpdb */
 		global $wpdb, $wp;
+
+		// Only modify headers for document revisions.
 		if ( isset( $wp->query_vars['post_type'] ) && 'document' !== $wp->query_vars['post_type'] ) {
 			return $headers;
 		}
 
+		// Retrieve post_content for the post matching this document request. This post_content is really
+		// the ID of the attachment the document is a mask for.
 		$post_id = $wpdb->get_var( $wpdb->prepare( "SELECT post_content FROM $wpdb->posts WHERE post_type='document' AND post_name = %s", sanitize_title( $wp->query_vars['name'] ) ) );
 		if ( empty( absint( $post_id ) ) ) {
 			return $headers;
 		}
+
+		// Retrieve the mime type assigned to the attachment originally.
 		$mime_type = $wpdb->get_var( $wpdb->prepare( "SELECT post_mime_type FROM $wpdb->posts WHERE ID = %d", $post_id ) );
 		if ( empty( $mime_type ) ) {
 			return $headers;


### PR DESCRIPTION
WP Document Revisions attempts to set a Content-Type header, but
WordPress sends the full set of headers to the browser before the
request is modified.

We hook in early here to provide Content-Type based on what we
know of the document from the save process. In the future it would
be nice to provide other header information as well.