### PR TITLE
[PR] Prevent WordPress from dropping tables for a deleted site.

### DIFF
--- a/wsuwp-admin.php
+++ b/wsuwp-admin.php
@@ -43,6 +43,9 @@ class WSU_Admin {
 		add_filter( 'user_has_cap', array( $this, 'user_can_switch_users' ), 10, 4 );
 
 		add_filter( 'wsuwp_sso_create_new_user', array( $this, 'create_auto_users' ) );
+
+		// Prevent WordPress from dropping tables for a deleted site.
+		add_filter( 'wpmu_drop_tables', '__return_empty_array' );
 	}
 
 	/**


### PR DESCRIPTION
We restrict the database user from using `DROP` in MySQL, so any
attempt will throw a warning into our error logs. We can avoid
this warning by skipping this section entirely.

See `wpmu_delete_blog()`