### PR TITLE
[PR] Remove TablePress WP Search integration

### DIFF
--- a/wsuwp-admin.php
+++ b/wsuwp-admin.php
@@ -67,6 +67,8 @@ class WSU_Admin {
 
 		add_filter( 'nocache_headers', array( $this, 'filter_404_no_cache_headers' ), 10 );
 		add_filter( 'post_password_expires', array( $this, 'filter_post_password_expires' ) );
+
+		add_filter( 'tablepress_wp_search_integration', '__return_false' );
 	}
 
 	/**


### PR DESCRIPTION
The addition of tables into general search queries is causing several
queries to take more than 10 seconds. As we aren't really taking
full advantage of WP Search at this time, we should be okay to
exclude this content for now.