### PR TITLE
[PR] Preconfigure some sites with S3 Uploads

### DIFF
--- a/wsuwp-admin.php
+++ b/wsuwp-admin.php
@@ -27,6 +27,7 @@ class WSU_Admin {
 		add_filter( 'srm_max_redirects', array( $this, 'srm_max_redirects' ), 10, 1 );
 		add_action( 'wpmu_new_blog', array( $this, 'preconfigure_project_site' ), 10, 3 );
 		add_action( 'wpmu_new_blog', array( $this, 'preconfigure_sites_site' ), 10, 3 );
+		add_action( 'wpmu_new_blog', array( $this, 'preconfigure_sites_with_s3_uploads' ), 10, 3 );
 		add_action( 'wsuwp_project_flush_rewrite_rules', array( $this, 'flush_rewrite_rules' ), 10 );
 
 		// Don't send submit for review emails in Duplicate and Merge Posts.
@@ -265,6 +266,33 @@ class WSU_Admin {
 			update_option( 'home', $home_url );
 		}
 
+		wp_cache_delete( 'alloptions', 'options' );
+		restore_current_blog();
+
+		refresh_blog_details( $blog_id );
+	}
+
+	/**
+	 * Sets new sites on specific domains to use S3 uploads on creation.
+	 *
+	 * @since 0.7.4
+	 *
+	 * @param int    $blog_id
+	 * @param int    $user_id
+	 * @param string $domain
+	 */
+	public function preconfigure_sites_with_s3_uploads( $blog_id, $user_id, $domain ) {
+		$forced_s3_domains = array(
+			'hub.wsu.edu',
+			'faculty.business.wsu.edu',
+		);
+
+		if ( ! in_array( $domain, $forced_s3_domains, true ) ) {
+			return;
+		}
+
+		switch_to_blog( $blog_id );
+		update_option( 's3_uploads_enabled', 'enabled' );
 		wp_cache_delete( 'alloptions', 'options' );
 		restore_current_blog();
 


### PR DESCRIPTION
All of the sites on these domains have been converted to use AWS S3 for uploads. The nginx config now expects uploads for these domains to be available through S3. Because of this, new sites under these domains should be preconfigured with S3.