### PR TITLE
[PR] Auto enable S3 uploads for new sites.wsu.edu sites

### DIFF
--- a/includes/class-wsuwp-admin.php
+++ b/includes/class-wsuwp-admin.php
@@ -342,6 +342,7 @@ class WSUWP_Admin {
 	 */
 	public function preconfigure_sites_with_s3_uploads( $blog_id, $user_id, $domain ) {
 		$forced_s3_domains = array(
+			'sites.wsu.edu',
 			'hub.wsu.edu',
 			'faculty.business.wsu.edu',
 		);

--- a/includes/class-wsuwp-admin.php
+++ b/includes/class-wsuwp-admin.php
@@ -342,6 +342,8 @@ class WSUWP_Admin {
 	 */
 	public function preconfigure_sites_with_s3_uploads( $blog_id, $user_id, $domain ) {
 		$forced_s3_domains = array(
+			'labs.wsu.edu',
+			'project.wsu.edu',
 			'sites.wsu.edu',
 			'hub.wsu.edu',
 			'faculty.business.wsu.edu',


### PR DESCRIPTION
I just moved all uploads for `sites.wsu.edu/*` sites to S3, so this should be locked too.