### PR TITLE
[PR] Revert use of wsu-search as an ES index, use wsu-web

### DIFF
--- a/includes/class-wsuwp-admin.php
+++ b/includes/class-wsuwp-admin.php
@@ -85,8 +85,6 @@ class WSUWP_Admin {
 
 		add_filter( 'tablepress_wp_search_integration', '__return_false' );
 		add_filter( 'wp_check_filetype_and_ext', array( $this, 'wp39550_disable_real_mime_check' ), 10, 4 );
-
-		add_filter( 'wsuwp_search_index_slug', array( $this, 'filter_search_index_slug' ), 10 );
 	}
 
 	/**
@@ -826,22 +824,5 @@ class WSUWP_Admin {
 		$proper_filename = $data['proper_filename'];
 
 		return compact( 'ext', 'type', 'proper_filename' );
-	}
-
-	/**
-	 * Filters the slug used to index saved data.
-	 *
-	 * @since 1.0.2
-	 *
-	 * @param string $slug
-	 *
-	 * @return string
-	 */
-	public function filter_search_index_slug( $slug ) {
-		if ( 'labs.wsu.edu' === get_site()->domain ) {
-			return 'wsu-search';
-		}
-
-		return $slug;
 	}
 }


### PR DESCRIPTION
In d14bf25f98d12571, I filtered the search index to use a new wsu-search instead of the default wsu-web, but failed to write any kind of commit message explaining the decision. Here we are months later and I'm trying to sort out *why*.

It appears that I did this so that the schema could be changed to be more filterable. Unfortunately, I picked a crappy name for the schema as this is all very WordPress specific and won't work for WSU search as a whole.

Let's revert to using wsu-web for now. We can redefine the schema attached to that and reindex sites using WP-CLI pretty easily.

This will free us up to use the wsu-search schema for an actual WSU search interface.