### PR TITLE
[PR] Refactor how headers are filtered in WP Document Revisions

### DIFF
--- a/includes/response-headers.php
+++ b/includes/response-headers.php
@@ -3,8 +3,9 @@
 namespace WSUWP\Admin\Response_Headers;
 
 add_filter( 'wp_headers', 'WSUWP\Admin\Response_Headers\filter_frame_headers', 20 );
-add_filter( 'wp_headers', 'WSUWP\Admin\Response_Headers\document_revisions_headers', 10 );
 add_filter( 'nocache_headers', 'WSUWP\Admin\Response_Headers\filter_404_no_cache_headers', 10 );
+add_filter( 'document_revisions_mimetype', '__return_false' );
+add_filter( 'document_revisions_serve_file_headers', 'WSUWP\Admin\Response_Headers\document_revisions_serve_file_headers', 10, 2 );
 
 /**
  * Removes the `X-Frame-Options: ALLOW-FROM` rule added by the Customizer Manager to avoid
@@ -28,63 +29,19 @@ function filter_frame_headers( $headers ) {
 }
 
 /**
- * Determine what Content-Type header should be sent with a document revisions
- * request. If we don't filter this, text/html is used by default as WordPress
- * sets the header before the WP Document Revisions plugin is able to.
+ * Filter the headers used when serving a file in WP Document Revisions.
  *
- * @since 0.3.1
+ * @since 1.2.1
  *
- * @global \wpdb $wpdb
- * @global \wp   $wp
+ * @param array $headers
+ * @param string $file
  *
- * @param array $headers List of headers currently set for this request.
- *
- * @return array Modified list of headers.
+ * @return array
  */
-function document_revisions_headers( $headers ) {
-	global $wpdb, $wp;
+function document_revisions_serve_file_headers( $headers, $file ) {
 
-	if ( 'documents/([0-9]{4})/([0-9]{1,2})/([^.]+)\.[A-Za-z0-9]{3,4}/?$' !== $wp->matched_rule ) {
-		return $headers;
-	}
-
-	// Only modify headers for document revisions.
-	if ( isset( $wp->query_vars['post_type'] ) && 'document' !== $wp->query_vars['post_type'] ) {
-		return $headers;
-	}
-
-	// Retrieve post_content for the post matching this document request. This post_content is really
-	// the ID of the attachment the document is a mask for.
-	$post_data = $wpdb->get_row( $wpdb->prepare( "SELECT post_content, post_password FROM $wpdb->posts WHERE post_type='document' AND post_name = %s", sanitize_title( $wp->query_vars['name'] ) ) );
-	$post_id = absint( $post_data->post_content );
-	$post_password = $post_data->post_password;
-
-	if ( empty( absint( $post_id ) ) ) {
-		return $headers;
-	}
-
-	// If the document has a password assigned and the cookie does not exist, don't modify.
-	if ( \WSUWP\Admin\Common\post_password_required( $post_password ) ) {
-		return $headers;
-	}
-
-	// Remove the default WordPress Link header.
-	remove_action( 'template_redirect', 'wp_shortlink_header', 11 );
-
-	// Remove the WP-API LINK header.
-	remove_action( 'template_redirect', 'json_output_link_header', 11 );
-
-	$file = get_attached_file( $post_id );
-
-	// No file exists to load.
-	if ( empty( $file ) ) {
-		return $headers;
-	}
-
-	/**
-	 * mime_content_type() is not handled by the S3 stream wrapper, so we
-	 * handle content type detection differently when S3 uploads are enabled.
-	 */
+	// mime_content_type() is not handled by the S3 stream wrapper used by S3 Uploads,
+	// so we handle content type detection differently when S3 Uploads is enabled.
 	if ( function_exists( 's3_uploads_enabled' ) && s3_uploads_enabled() ) {
 		include_once __DIR__ . '/upstream-file-mime-type-mapping.php';
 		$mime_type_mapping = wsuwp_file_default_mimetype_mapping();
@@ -93,16 +50,12 @@ function document_revisions_headers( $headers ) {
 		$mime_type = mime_content_type( $file );
 	}
 
-	$file_size = filesize( $file );
-	if ( empty( $mime_type ) ) {
-		return $headers;
-	}
-
-	$headers['Content-Length'] = $file_size;
 	$headers['Content-Type'] = $mime_type;
 	$headers['Accept-Ranges'] = 'bytes';
 
-	unset( $headers['X-Pingback'] );
+	// Remove the expires header completely so that revisions appear to the public quickly.
+	unset( $headers['Expires'] );
+
 	return $headers;
 }
 


### PR DESCRIPTION
With new upstream changes in WP Document Revisions, we can have more granular control over the headers sent by the plugin.