### PR TITLE
[PR] Remove the Gravity Forms "System Status" page from the admin

### DIFF
--- a/includes/gravity-forms.php
+++ b/includes/gravity-forms.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace WSUWP\Admin\GravityForms;
+
+add_action( 'admin_menu', 'WSUWP\Admin\GravityForms\remove_system_status', 999 );
+
+/**
+ * Remove the Gravity Forms "System Status" page from the admin.
+ *
+ * @since 1.6.0
+ */
+function remove_system_status() {
+	remove_submenu_page( 'gf_edit_forms', 'gf_system_status' );
+}

--- a/wsuwp-admin.php
+++ b/wsuwp-admin.php
@@ -42,4 +42,5 @@ if ( version_compare( PHP_VERSION, '5.3', '<' ) ) {
 	include_once __DIR__ . '/includes/wsuwp-admin-remarketing.php';
 	include_once __DIR__ . '/includes/response-headers.php';
 	include_once __DIR__ . '/includes/content-visibility.php';
+	include_once __DIR__ . '/includes/gravity-forms.php';
 }


### PR DESCRIPTION
This is all something we track in other places and may be confusing to a site admin.